### PR TITLE
Frontend Register, utils con pylint y README.md de tests

### DIFF
--- a/auth-service/app/utils.py
+++ b/auth-service/app/utils.py
@@ -1,24 +1,59 @@
-# app/utils.py
-from passlib.context import CryptContext
-from datetime import datetime, timedelta
-from jose import JWTError, jwt
+"""
+utils.py - Utility functions for authentication service.
+
+This module provides utility functions for password hashing, password verification,
+JWT token creation, and token validation.
+"""
 import os
+from datetime import datetime, timedelta
+from passlib.context import CryptContext
+from jose import JWTError, jwt
 from app.models import User, SessionLocal
+
 # Setup the password context for hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 # Secret key to encode JWT
 SECRET_KEY = os.getenv("SECRET_KEY")
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 100))
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "100"))
 
-def get_password_hash(password):
+def get_password_hash(password: str) -> str:
+    """
+    Hashes the given password.
+
+    Args:
+        password (str): The password to hash.
+
+    Returns:
+        str: The hashed password.
+    """
     return pwd_context.hash(password)
 
-def verify_password(plain_password, hashed_password):
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """
+    Verifies that the plain password matches the hashed password.
+
+    Args:
+        plain_password (str): The plain password to verify.
+        hashed_password (str): The hashed password to compare against.
+
+    Returns:
+        bool: True if the passwords match, False otherwise.
+    """
     return pwd_context.verify(plain_password, hashed_password)
 
-def create_access_token(data: dict, expires_delta: timedelta = None):
+def create_access_token(data: dict, expires_delta: timedelta = None) -> str:
+    """
+    Creates a JWT token.
+
+    Args:
+        data (dict): The data to include in the token.
+        expires_delta (timedelta, optional): The time duration for the token to expire.
+
+    Returns:
+        str: The encoded JWT token.
+    """
     to_encode = data.copy()
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
@@ -28,17 +63,29 @@ def create_access_token(data: dict, expires_delta: timedelta = None):
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
-def validate_token(token: str):
+def validate_token(token: str) -> dict:
+    """
+    Validates the given JWT token.
+
+    Args:
+        token (str): The JWT token to validate.
+
+    Returns:
+        dict: The decoded token data with user_id.
+
+    Raises:
+        JWTError: If the token is invalid or expired.
+    """
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         print(payload)
         user_id: int = payload.get("user_id")
         if user_id is None:
-            raise JWTError("Token inválido")
+            raise JWTError("Invalid token")
         db = SessionLocal()
         user = db.query(User).filter(User.id == user_id).first()
         if user is None:
-            raise JWTError("Token inválido")
+            raise JWTError("Invalid token")
         return {"user_id": user_id}
-    except JWTError:
-        raise JWTError("Token inválido")
+    except JWTError as exc:
+        raise JWTError("Invalid token") from exc

--- a/auth-service/tests/README.md
+++ b/auth-service/tests/README.md
@@ -1,0 +1,47 @@
+
+# Testing Guide
+## Introduction
+
+Este documento explica cómo configurar y ejecutar pruebas para los microservicios `auth-service` y `chat-service`. Utilizamos `pytest` como marco de pruebas.
+
+## Pasos para Configurar y Ejecutar las Pruebas
+
+### 1. Moverse a la Carpeta del Microservicio
+Primero, navega a la carpeta del microservicio que deseas probar. Por ejemplo:
+```bash
+cd auth-service
+```
+
+### 2. Crear y Configurar Variables de Entorno
+Cada microservicio requiere variables de entorno específicas. Puedes encontrar un archivo de ejemplo (.envexample) en la raíz de cada carpeta del microservicio. Copia este archivo y renómbralo a .env:
+```bash
+cp .envexample .env
+```
+
+### 3. Crear y Activar un Entorno Virtual
+Crea un entorno virtual en la carpeta del microservicio:
+```bash
+python -m venv venv
+```
+
+### Activa el entorno virtual:
+En Windows:
+```bash
+venv\Scripts\activate
+```
+
+En macOS y Linux:
+```bash
+source venv/bin/activate
+```
+### 4. Instalar los Requisitos
+Con el entorno virtual activado, instala las dependencias necesarias:
+```bash
+pip install -r requirements.txt
+```
+### 5. Ejecutar Pytest
+Finalmente, ejecuta las pruebas utilizando pytest:
+
+```bash
+pytest
+```

--- a/chat-service/app/utils.py
+++ b/chat-service/app/utils.py
@@ -1,20 +1,36 @@
-# app/utils.py
+"""
+utils.py - Utility functions for chat service.
+
+This module provides utility functions for token verification and interacting with OpenAI API.
+"""
+
 import os
-from datetime import datetime, timedelta
-from fastapi import HTTPException, Depends, Request
-from fastapi.security import OAuth2PasswordBearer
 import requests
+from datetime import datetime, timedelta
+from fastapi import HTTPException
+from fastapi.security import OAuth2PasswordBearer
 from openai import OpenAI
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 30))
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30"))
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
-def verify_token(token: str):
+def verify_token(token: str) -> dict:
+    """
+    Verifies the given token with the authentication service.
+
+    Args:
+        token (str): The token to verify.
+
+    Returns:
+        dict: The user data if the token is valid.
+
+    Raises:
+        HTTPException: If the token is invalid or expired.
+    """
     auth_service_url = os.getenv("AUTH_SERVICE_URL", "http://localhost:8000")
-    #print(token)
     response = requests.get(f"{auth_service_url}/validate-token", headers={"Authorization": f"Bearer {token}"})
     if response.status_code != 200:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
@@ -23,16 +39,25 @@ def verify_token(token: str):
         raise HTTPException(status_code=401, detail="Invalid or expired token")
     return user_data
 
-def get_openai_completion(user_msg: str):
+def get_openai_completion(user_msg: str) -> str:
+    """
+    Gets a completion from the OpenAI chat model based on the user message.
+
+    Args:
+        user_msg (str): The user message to send to the OpenAI chat model.
+
+    Returns:
+        str: The completion message from the OpenAI chat model.
+    """
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
     client = OpenAI(api_key=OPENAI_API_KEY)
 
     completion = client.chat.completions.create(
-    model="gpt-3.5-turbo-16k",
-    messages=[
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": user_msg}
-    ]
+        model="gpt-3.5-turbo-16k",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": user_msg}
+        ]
     )
 
     print(completion.choices[0].message)

--- a/chat-service/tests/README.md
+++ b/chat-service/tests/README.md
@@ -1,0 +1,47 @@
+
+# Testing Guide
+## Introduction
+
+Este documento explica cómo configurar y ejecutar pruebas para los microservicios `auth-service` y `chat-service`. Utilizamos `pytest` como marco de pruebas.
+
+## Pasos para Configurar y Ejecutar las Pruebas
+
+### 1. Moverse a la Carpeta del Microservicio
+Primero, navega a la carpeta del microservicio que deseas probar. Por ejemplo:
+```bash
+cd chat-service
+```
+
+### 2. Crear y Configurar Variables de Entorno
+Cada microservicio requiere variables de entorno específicas. Puedes encontrar un archivo de ejemplo (.envexample) en la raíz de cada carpeta del microservicio. Copia este archivo y renómbralo a .env:
+```bash
+cp .envexample .env
+```
+
+### 3. Crear y Activar un Entorno Virtual
+Crea un entorno virtual en la carpeta del microservicio:
+```bash
+python -m venv venv
+```
+
+### Activa el entorno virtual:
+En Windows:
+```bash
+venv\Scripts\activate
+```
+
+En macOS y Linux:
+```bash
+source venv/bin/activate
+```
+### 4. Instalar los Requisitos
+Con el entorno virtual activado, instala las dependencias necesarias:
+```bash
+pip install -r requirements.txt
+```
+### 5. Ejecutar Pytest
+Finalmente, ejecuta las pruebas utilizando pytest:
+
+```bash
+pytest
+```

--- a/frontend-service/src/App.js
+++ b/frontend-service/src/App.js
@@ -1,5 +1,6 @@
 import Home from "./pages/Home";
 import Login from "./pages/Login";
+import Register from "./pages/Register";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { AuthProvider } from "./contexts/AuthContext";
 
@@ -16,9 +17,10 @@ function App() {
     <AuthProvider>
       <div className="App">
         <Routes>
-          <Route exact path="/" element={<Navigate to="/auth" />} />
+          <Route exact path="/" element={<Navigate to="/register" />} />
           <Route exact path="/home" element={<Home />} />
           <Route exact path="/auth" element={<Login />} />
+          <Route exact path="/register" element={<Register/>} />
         </Routes>
       </div>
     </AuthProvider>

--- a/frontend-service/src/pages/Register.jsx
+++ b/frontend-service/src/pages/Register.jsx
@@ -1,0 +1,65 @@
+import React, { useState, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import { AuthContext } from "../contexts/AuthContext";
+import './Login.css';
+
+const Register = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const navigate = useNavigate();
+  const { setAuthToken } = useContext(AuthContext);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      const response = await axios.post("http://localhost:8000/register", {
+        email: email,
+        password: password
+      });
+      const token = response.data.access_token;
+      setAuthToken(token);
+      navigate("/auth"); // Redirigir a la página login
+    } catch (error) {
+      console.error("Error during registering:", error);
+      // Manejar errores de inicio de sesión aquí
+    }
+  };
+  const handleLoginRedirect = () => {
+    navigate("/auth"); // Redirigir a la página login
+  };
+
+  return (
+    <div className="login-container">
+      <h1>Register</h1>
+      <form onSubmit={handleSubmit} className="login-form">
+        <div className="form-group">
+          <label>Email:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            style={{ color: "black" }} // Letras negras
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label>Contraseña:</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            style={{ color: "black" }} // Letras negras
+            required
+          />
+        </div>
+        <button type="submit">Done</button>
+        <button type="button" onClick={handleLoginRedirect}>
+          Ya estoy registrad@
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Register;


### PR DESCRIPTION
Se agrega Register desde front-end sin necesidad de postman así como también una opción para decir que ya estás registrado, ya que el puerto 3000 carga desde el principio hacia Registrar. Se agregan comentarios en Utils con formato pylint y se creó un README.md para ambos tests